### PR TITLE
7 lytix activity import externallib

### DIFF
--- a/classes/activity_lib.php
+++ b/classes/activity_lib.php
@@ -29,7 +29,11 @@
 
 namespace lytix_activity;
 
-use context_course;
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("{$CFG->libdir}/externallib.php");
+
 use lytix_helper\calculation_helper;
 use lytix_helper\course_settings;
 

--- a/version.php
+++ b/version.php
@@ -31,9 +31,7 @@ $plugin->component    = 'lytix_activity'; // Full name of the plugin.
 $plugin->dependencies = [
     'lytix_helper'          => ANY_VERSION,
     'lytix_logs'            => ANY_VERSION,
-    'lytix_config'          => ANY_VERSION,
-    'lytix_planner'         => ANY_VERSION,
-    'lytix_timeoverview'    => ANY_VERSION
+    'lytix_config'          => ANY_VERSION
 ];
-$plugin->release   = 'v1.0.7';
+$plugin->release   = 'v1.0.8';
 $plugin->supported = [401, 403];


### PR DESCRIPTION
- Changed the import of externallib to work for both Moodle 4.1 and 4.2+.
- Changed the import to work for Moodle 4.2 and the testmatrix for Moodle 4.2 + PHP 8.2+